### PR TITLE
response format change

### DIFF
--- a/src/Controllers/PaymentController.php
+++ b/src/Controllers/PaymentController.php
@@ -56,7 +56,7 @@ class PaymentController extends Controller
         $pay_instance->setClientSecretFromObj($response);
         $pay_instance->setStatusFromObj($response);
         $pay_instance->request_options = $request->all();
-        $pay_instance->response_object = $response;
+        $pay_instance->response_object = $response->toArray();
         $pay_instance->save();
 
         event(new PaymentInstanceCreated($pay_instance));

--- a/src/Controllers/PaymentController.php
+++ b/src/Controllers/PaymentController.php
@@ -56,7 +56,7 @@ class PaymentController extends Controller
         $pay_instance->setClientSecretFromObj($response);
         $pay_instance->setStatusFromObj($response);
         $pay_instance->request_options = $request->all();
-        $pay_instance->response_object = $response->toArray();
+        $pay_instance->response_object = json_encode($response);
         $pay_instance->save();
 
         event(new PaymentInstanceCreated($pay_instance));


### PR DESCRIPTION
we are storing response in json string instead of the string generated by stripe, that way it will be more reliable, even it will work fine with paypal.