### PR TITLE
User extract from the package

### DIFF
--- a/src/Contracts/PaymentUserContract.php
+++ b/src/Contracts/PaymentUserContract.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Immera\Payment\Contracts;
+
+interface PaymentUserContract {
+    public function getName();
+    public function getEmail();
+    public function getId();
+}

--- a/src/Payment.php
+++ b/src/Payment.php
@@ -16,15 +16,16 @@ class Payment
     protected $stripe;
     protected StripeCustomer $customer;
 
-    public function __construct(PaymentUserContract $user)
+    public function __construct(PaymentUserContract $user = NULL)
     {
         $stripe_key = config('payment.stripe.secret_key');
         $this->stripe = $stripe_key !== null ? new StripeClient($stripe_key) : null;
         $this->setCustomer($user);
     }
 
-    public function setCustomer(PaymentUserContract $user)
+    public function setCustomer(PaymentUserContract $user = NULL)
     {
+        if($user === NULL) $user = Auth::user();
         $cust = Customer::getCustomer($user->getId());
         if ($cust != null && $cust->stripe_customer_id != null) {
             $this->customer = new StripeCustomer($cust->stripe_customer_id, $user->getName(), $user->getEmail());

--- a/src/Payment.php
+++ b/src/Payment.php
@@ -9,36 +9,36 @@ use Immera\Payment\StripeCustomer;
 use Immera\Payment\Models\PaymentInstance;
 use Immera\Payment\Events\PaymentInstanceUpdated;
 use Illuminate\Support\Facades\Http;
+use Immera\Payment\Contracts\PaymentUserContract;
 
 class Payment
 {
     protected $stripe;
     protected StripeCustomer $customer;
 
-    public function __construct()
+    public function __construct(PaymentUserContract $user)
     {
         $stripe_key = config('payment.stripe.secret_key');
         $this->stripe = $stripe_key !== null ? new StripeClient($stripe_key) : null;
-        $this->setCustomer();
+        $this->setCustomer($user);
     }
 
-    public function setCustomer(string $email = "")
+    public function setCustomer(PaymentUserContract $user)
     {
-        $user = Auth::user();
-        $cust = Customer::getCustomer($user->id);
+        $cust = Customer::getCustomer($user->getId());
         if ($cust != null && $cust->stripe_customer_id != null) {
-            $this->customer = new StripeCustomer($cust->stripe_customer_id, $user->full_name, $user->email);
+            $this->customer = new StripeCustomer($cust->stripe_customer_id, $user->getName(), $user->getEmail());
         } else {
             $stripeCust = $this->stripe->customers->create([
-                'name' => $user->full_name,
-                'email' => $user->email,
+                'name' => $user->getName(),
+                'email' => $user->getEmail(),
             ]);
             Customer::create([
-                'user_id' => $user->id,
+                'user_id' => $user->getId(),
                 'stripe_customer_id' => $stripeCust->id,
                 'invoice_prefix' => $stripeCust->invoice_prefix,
             ]);
-            $this->customer = new StripeCustomer($stripeCust->id, $user->full_name, $user->email);
+            $this->customer = new StripeCustomer($stripeCust->id, $user->getName(), $user->getEmail());
         }
     }
 


### PR DESCRIPTION
added facility to provide user object outside from the package, and if it's not provided then we will take authenticated user from the package.

This required to keep the package working even it not called from regular http request, instead it called from the event handler, where we don't have that authenticated user in the context.